### PR TITLE
feat: props blueprint

### DIFF
--- a/examples/attach-effect/Counter.mjs
+++ b/examples/attach-effect/Counter.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { WebComponent, attachEffect } from "../../src/";
+import { WebComponent, attachEffect } from "../../src/index.js";
 export class Counter extends WebComponent {
   static properties = ["count"];
   onInit() {

--- a/examples/attach-effect/Decrease.mjs
+++ b/examples/attach-effect/Decrease.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { WebComponent, attachEffect } from "../../src/";
+import { WebComponent, attachEffect } from "../../src/index.js";
 
 export class Decrease extends WebComponent {
   static properties = ["count"];

--- a/examples/demo/BooleanPropTest.mjs
+++ b/examples/demo/BooleanPropTest.mjs
@@ -1,4 +1,4 @@
-import { WebComponent } from "../../src";
+import { WebComponent } from "../../src/index.js"
 
 export class BooleanPropTest extends WebComponent {
   static properties = ["is-inline", "anotherone"];

--- a/examples/demo/Counter.mjs
+++ b/examples/demo/Counter.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { WebComponent } from "../../src";
+import { WebComponent } from "../../src/index.js"
 
 export class Counter extends WebComponent {
   static properties = ["count"];

--- a/examples/demo/HelloWorld.mjs
+++ b/examples/demo/HelloWorld.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { WebComponent } from "../../src";
+import { WebComponent } from "../../src/index.js"
 
 export class HelloWorld extends WebComponent {
   static properties = ["count", "emotion"];

--- a/examples/demo/SimpleText.mjs
+++ b/examples/demo/SimpleText.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { WebComponent } from "../../src"
+import { WebComponent } from "../../src/index.js"
 
 class SimpleText extends WebComponent {
   clickCallback() {

--- a/examples/props-blueprint/hello-world.js
+++ b/examples/props-blueprint/hello-world.js
@@ -1,0 +1,12 @@
+import { WebComponent } from "../../src/index.js";
+
+export class HelloWorld extends WebComponent {
+  static props = {
+    myName: 'World',
+  };
+  get template() {
+    return `<p>Hello ${this.props.myName}</p>`;
+  }
+}
+
+customElements.define("hello-world", HelloWorld);

--- a/examples/props-blueprint/index.html
+++ b/examples/props-blueprint/index.html
@@ -5,8 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WC demo</title>
     <script type="module" src="./index.js"></script>
+    <script type="module" src="./hello-world.js"></script>
   </head>
   <body>
     <my-counter></my-counter>
+    <hello-world></hello-world>
   </body>
 </html>

--- a/examples/props-blueprint/index.html
+++ b/examples/props-blueprint/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WC demo</title>
+    <script type="module" src="./index.js"></script>
+  </head>
+  <body>
+    <my-counter></my-counter>
+  </body>
+</html>

--- a/examples/props-blueprint/index.js
+++ b/examples/props-blueprint/index.js
@@ -1,0 +1,16 @@
+import { WebComponent } from "../../src/index.js";
+
+export class Counter extends WebComponent {
+  static props = {
+    count: 123,
+    myName: 'Ayo'
+  };
+  onInit() {
+    this.onclick = () => ++this.props.count;
+  }
+  get template() {
+    return `<button id="btn">${this.props.count}</button><p>${this.props.myName}</p>`;
+  }
+}
+
+customElements.define("my-counter", Counter);

--- a/examples/props-blueprint/index.js
+++ b/examples/props-blueprint/index.js
@@ -3,13 +3,12 @@ import { WebComponent } from "../../src/index.js";
 export class Counter extends WebComponent {
   static props = {
     count: 123,
-    myName: 'Ayo'
   };
   onInit() {
     this.onclick = () => ++this.props.count;
   }
   get template() {
-    return `<button id="btn">${this.props.count}</button><p>${this.props.myName}</p>`;
+    return `<button id="btn">${this.props.count}</button>`;
   }
 }
 

--- a/examples/type-restore/Object.mjs
+++ b/examples/type-restore/Object.mjs
@@ -1,12 +1,12 @@
 import { WebComponent } from "../../src/WebComponent.js";
 
 export class ObjectText extends WebComponent {
-  static properties = ["object"];
-  onInit() {
-    this.props.object = {
-        hello: 'worldzz',
-        age: 2
-    };
+  // static properties = ["object"];
+  static props = {
+    object: {
+      hello: 'worldzz',
+      age: 2
+    }
   }
   onChanges() {
     console.log('>>> object', this.props.object)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-base",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "A zero-dependency, ~600 Bytes (minified & gzipped), JS base class for creating reactive custom elements easily",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-base",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "A zero-dependency, ~600 Bytes (minified & gzipped), JS base class for creating reactive custom elements easily",
   "type": "module",
   "exports": {

--- a/src/WebComponent.js
+++ b/src/WebComponent.js
@@ -79,7 +79,7 @@ export class WebComponent extends HTMLElement {
   }
 
   static get observedAttributes() {
-    const propKeys = Object.keys(this.props).map(camelCase => getKebabCase(camelCase))
+    const propKeys = this.props ? Object.keys(this.props).map(camelCase => getKebabCase(camelCase)) : [];
 
     return [...(
       new Set([


### PR DESCRIPTION
🎉 New way to define and initialize props on WebComponent.io as of v2.0.0-beta.6

This should ease the friction in defining properties with kebab-case strings and switching to camelCase when working with the values. Also, needing to initialize the values inside the onInit hook is unnecessary now.


```js
export class Counter extends WebComponent {
  static props = {
    count: 123,
  };
  onInit() {
    this.onclick = () => ++this.props.count;
  }
  get template() {
    return `<button id="btn">${this.props.count}</button>`;
  }
}
```