### PR TITLE
docs: switch typed-props pattern to named type above, defaults within

### DIFF
--- a/demo/examples/typed-props/index.ts
+++ b/demo/examples/typed-props/index.ts
@@ -1,13 +1,19 @@
 import { WebComponent, html } from 'web-component-base'
 
-const buttonProps = {
-  variant: 'primary',
-  disabled: false,
-  clicks: 0,
+// the type above, the defaults within: unions stay narrow with nothing to
+// cast, and the annotation checks the defaults themselves too
+type TypedButtonProps = {
+  variant: 'primary' | 'secondary' | 'ghost'
+  disabled: boolean
+  clicks: number
 }
 
-class TypedButton extends WebComponent<typeof buttonProps> {
-  static props = buttonProps
+class TypedButton extends WebComponent<TypedButtonProps> {
+  static props: TypedButtonProps = {
+    variant: 'primary',
+    disabled: false,
+    clicks: 0,
+  }
 
   bump = () => {
     if (!this.props.disabled) this.props.clicks++
@@ -16,15 +22,15 @@ class TypedButton extends WebComponent<typeof buttonProps> {
   toggle = () => (this.props.disabled = !this.props.disabled)
 
   cycle = () => {
-    const order = ['primary', 'secondary', 'ghost']
+    const order = ['primary', 'secondary', 'ghost'] as const
     const next = order[(order.indexOf(this.props.variant) + 1) % order.length]
     this.props.variant = next
   }
 
   get template() {
-    // Each read below is inferred from the default it was declared with —
-    // hover them in an editor to see `string`, `boolean` and `number`.
-    const variant: string = this.props.variant
+    // Each read below is typed by the declaration above — hover them in an
+    // editor to see the variant union, `boolean` and `number`.
+    const variant: TypedButtonProps['variant'] = this.props.variant
     const disabled: boolean = this.props.disabled
     const clicks: number = this.props.clicks
 
@@ -49,16 +55,20 @@ class TypedButton extends WebComponent<typeof buttonProps> {
  * ERROR examples
  * `@ts-expect-error` keeps this example working
  */
-class CompileErrors extends WebComponent<typeof buttonProps> {
-  static props = buttonProps
+class CompileErrors extends WebComponent<TypedButtonProps> {
+  static props: TypedButtonProps = {
+    variant: 'primary',
+    disabled: false,
+    clicks: 0,
+  }
 
   demo() {
     // if you remove the ts-expect-error comment below, the editor should show red squiggly lines
     // @ts-expect-error string is not assignable to boolean
     this.props.disabled = 'yes'
 
-    // @ts-expect-error boolean is not assignable to string
-    this.props.variant = false
+    // @ts-expect-error 'plaid' is not in the variant union
+    this.props.variant = 'plaid'
 
     // @ts-expect-error 'varient' is a typo — not a declared prop
     this.props.varient

--- a/docs/src/content/docs/guides/prop-access.mdx
+++ b/docs/src/content/docs/guides/prop-access.mdx
@@ -253,32 +253,45 @@ reason.
 
 See it live: [Compile-time prop types demo ↗](https://demo.webcomponent.io/examples/typed-props/) and [Typed props demo ↗](https://demo.webcomponent.io/examples/type-restore/)
 
-By default `this.props` is a permissive `{ [name: string]: any }` map. In TypeScript you can get compile-time types on your declared props by passing the shape of your defaults as a type argument to `WebComponent`. Declare the defaults in a `const` first so the class can refer to their type:
+By default `this.props` is a permissive `{ [name: string]: any }` map. In TypeScript you can get compile-time types on your declared props: declare the shape as a named type, pass it as the class type argument, and annotate `static props` with it — the type above, the defaults within:
 
 ```ts
-const props = {
-  variant: 'primary',
-  disabled: false,
+type CozyButtonProps = {
+  variant: 'primary' | 'ghost'
+  disabled: boolean
 }
 
-class CozyButton extends WebComponent<typeof props> {
-  static props = props
+class CozyButton extends WebComponent<CozyButtonProps> {
+  static props: CozyButtonProps = {
+    variant: 'primary',
+    disabled: false,
+  }
 
   get template() {
-    this.props.variant // string
+    this.props.variant // 'primary' | 'ghost'
     this.props.disabled // boolean
     this.props.notAProp // ❌ compile error: not declared
 
     this.props.disabled = 'yes' // ❌ compile error: string is not boolean
+    this.props.variant = 'plaid' // ❌ compile error: not in the union
     return html`<button class=${this.props.variant}></button>`
   }
 }
 ```
 
+Unions stay narrow with nothing to cast, and the annotation cuts both ways:
+the defaults themselves are checked against the type, so a missing key or a
+default outside the union is a compile error too.
+
 This is types-only — the runtime is unchanged, and `static strictProps` still guards writes that come in from attributes at runtime. Omitting the type argument keeps the previous untyped behavior.
 
 <Aside type="tip">
-Values in the defaults object widen as usual, so `variant: 'primary'` types as `string`. To narrow it to a union of allowed values, annotate the defaults: `const props = { variant: 'primary' as 'primary' | 'ghost' }`.
+  You can also infer the type from the defaults instead of writing it out:
+  declare them in a `const` and pass its `typeof` —
+  `class CozyButton extends WebComponent<typeof props> { static props = props }`.
+  Inferred values widen (`variant: 'primary'` types as plain `string`), so
+  narrow with a cast where it matters:
+  `variant: 'primary' as 'primary' | 'ghost'`.
 </Aside>
 
 ### Unobserved properties

--- a/test/types/typed-props.test-d.ts
+++ b/test/types/typed-props.test-d.ts
@@ -19,7 +19,9 @@ class CozyButton extends WebComponent<typeof buttonProps> {
   get template() {
     // reads are inferred from the defaults, not `any`
     type _variantIsString = Expect<Equals<typeof this.props.variant, string>>
-    type _disabledIsBoolean = Expect<Equals<typeof this.props.disabled, boolean>>
+    type _disabledIsBoolean = Expect<
+      Equals<typeof this.props.disabled, boolean>
+    >
 
     return `<button class="${this.props.variant}"></button>`
   }
@@ -39,6 +41,35 @@ class CozyButton extends WebComponent<typeof buttonProps> {
   }
 }
 
+// the same contract holds with an explicit named type — the type above, the
+// defaults within — where unions stay narrow and the annotation also checks
+// the defaults themselves
+type IndicatorProps = {
+  status: 'default' | 'active' | 'negative'
+  pulse: boolean
+}
+
+class StatusIndicator extends WebComponent<IndicatorProps> {
+  static props: IndicatorProps = { status: 'default', pulse: false }
+
+  read() {
+    type _statusIsUnion = Expect<
+      Equals<typeof this.props.status, 'default' | 'active' | 'negative'>
+    >
+    type _pulseIsBoolean = Expect<Equals<typeof this.props.pulse, boolean>>
+  }
+
+  wrong() {
+    // @ts-expect-error 'blinking' is not in the union
+    this.props.status = 'blinking'
+  }
+}
+
+class BadDefaults extends WebComponent<IndicatorProps> {
+  // @ts-expect-error missing 'pulse', and 'blinking' is outside the union
+  static props: IndicatorProps = { status: 'blinking' }
+}
+
 // without a type argument, props stays the permissive PropStringMap
 class Untyped extends WebComponent {
   static props = { anything: 1 }
@@ -47,4 +78,4 @@ class Untyped extends WebComponent {
   }
 }
 
-export type { CozyButton, Untyped }
+export type { CozyButton, StatusIndicator, BadDefaults, Untyped }


### PR DESCRIPTION
Follow-up to the prop-access docs work merged in cdfe928.

Replaces the `const` + `typeof` typed-props example with the clearer form used in [status-indicator](https://github.com/ayo-run/status-indicator/blob/main/src/status-indicator.ts): declare the props shape as a named type, pass it as the class type argument, and annotate `static props` with it — the type above, the defaults within.

```ts
type CozyButtonProps = {
  variant: 'primary' | 'ghost'
  disabled: boolean
}

class CozyButton extends WebComponent<CozyButtonProps> {
  static props: CozyButtonProps = {
    variant: 'primary',
    disabled: false,
  }
}
```

What this form buys, now called out in the prose:
- unions stay narrow with nothing to cast (`variant` reads as `'primary' | 'ghost'`)
- the annotation cuts both ways: the defaults themselves are checked, so a missing key or an out-of-union default is a compile error

The `typeof`-inference form remains documented as the alternative in the tip aside, with its widening caveat.

Kept in lockstep (all covered by `pnpm test:types`):
- `demo/examples/typed-props/index.ts` — `TypedButton`/`CompileErrors` use the named-type style; `cycle()` gets `as const` so the computed variant stays in the union
- `test/types/typed-props.test-d.ts` — new named-type coverage: union reads, out-of-union writes rejected, and a `BadDefaults` class proving the defaults are validated; existing `typeof` coverage stays

Verified with `pnpm test:types` (both tsc projects) plus the full unit + e2e suite via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGvhWcxLjxJyvMKw1pA1qr

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGvhWcxLjxJyvMKw1pA1qr)_