### PR TITLE
docs: align cem-plugin example with the typed-props pattern

### DIFF
--- a/demo/examples/typed-props/index.html
+++ b/demo/examples/typed-props/index.html
@@ -17,9 +17,9 @@
   <body>
     <h1>Compile-time prop types</h1>
     <p>
-      Pass the shape of your defaults as a type argument —
-      <code>extends WebComponent&lt;typeof props&gt;</code> — and
-      <code>this.props.*</code> is inferred from them instead of being
+      Declare the shape as a named type and pass it as the class type
+      argument — <code>extends WebComponent&lt;TypedButtonProps&gt;</code> —
+      and <code>this.props.*</code> is checked against it instead of being
       <code>any</code>.
     </p>
 

--- a/docs/src/content/docs/api/cem-plugin.md
+++ b/docs/src/content/docs/api/cem-plugin.md
@@ -51,5 +51,5 @@ initializer and, for every key, records in the manifest:
 Without it the analyzer sees `props` as one opaque static field and emits no
 attributes, so editor completion and Storybook controls have nothing to read.
 
-The `static props` object may be declared inline or as an identifier resolved
-from the same source file.
+The `static props` initializer must resolve to an object literal in the same
+source file.

--- a/docs/src/content/docs/api/web-component.md
+++ b/docs/src/content/docs/api/web-component.md
@@ -20,10 +20,16 @@ In TypeScript, pass the shape of `static props` as a type argument to get a
 typed `this.props`:
 
 ```ts
-const props = { variant: 'primary', disabled: false }
+type CozyButtonProps = {
+  variant: 'primary' | 'ghost'
+  disabled: boolean
+}
 
-class CozyButton extends WebComponent<typeof props> {
-  static props = props
+class CozyButton extends WebComponent<CozyButtonProps> {
+  static props: CozyButtonProps = {
+    variant: 'primary',
+    disabled: false,
+  }
 }
 ```
 

--- a/docs/src/content/docs/guides/cem-plugin.mdx
+++ b/docs/src/content/docs/guides/cem-plugin.mdx
@@ -124,18 +124,36 @@ Bind a story to the tag name and Storybook infers the rest, giving a text field 
 ```js
 // cozy-button.stories.js
 import { html } from 'lit'
-import '../src/cozy-button.js'
+import '../src/cozy-button.ts'
 
 export default {
   title: 'Cozy/Button',
   component: 'cozy-button', // ← no argTypes needed
-  render: ({ variant, disabled }) => html`
-    <cozy-button variant=${variant} disabled=${disabled}></cozy-button>
+  render: ({ variant, disabled, maxCount }) => html`
+    <cozy-button
+      variant=${variant}
+      ?disabled=${disabled}
+      max-count=${maxCount}
+    ></cozy-button>
   `,
 }
 
-export const Default = { args: { variant: 'primary', disabled: false } }
+export const Default = {
+  args: { variant: 'primary', disabled: false, maxCount: 3 },
+}
 ```
+
+<Aside type="note" title="The `html` in story files is lit's, not wcb's">
+  Storybook's web-components renderer renders stories with
+  [lit-html](https://lit.dev/docs/templates/overview/), so story files import
+  `html` from `lit` and templates in them use **lit's binding syntax** — the
+  `?disabled=${disabled}` prefix above is lit for "add or remove the boolean
+  attribute" (a plain `disabled=${false}` would write `disabled="false"`,
+  which wcb [parses as `true`](/prop-access/#boolean-props)). None of this
+  applies to your component: it keeps wcb's own `html` tag with no special
+  binding prefixes, and lit is a devDependency of the Storybook setup, never
+  shipped with the component.
+</Aside>
 
 <Aside type="tip">
   Regenerate the manifest before starting Storybook (`cem analyze && storybook

--- a/docs/src/content/docs/guides/cem-plugin.mdx
+++ b/docs/src/content/docs/guides/cem-plugin.mdx
@@ -103,8 +103,6 @@ Two details worth knowing:
 - **Types come from the default literal**: `true`/`false` → `boolean`, numeric → `number`, object/array → `object`, everything else → `string`. The TypeScript annotation is not consulted, so `variant`'s union still lands in the manifest as `string`.
 - **Attribute names come from wcb's own `getKebabCase`**, the same function `observedAttributes` uses, so manifest names can't drift from what the component actually observes.
 
-The defaults may be written inline as above, or hoisted into a module-level `const` — the shape the inferred variant of the [typed props](/prop-access/#typed-props-in-typescript) pattern uses (`WebComponent<typeof props>`). The plugin resolves both.
-
 ## Storybook
 
 Storybook's web-components renderer builds **autodocs and controls** from a [Custom Elements Manifest](https://github.com/webcomponents/custom-elements-manifest).

--- a/docs/src/content/docs/guides/cem-plugin.mdx
+++ b/docs/src/content/docs/guides/cem-plugin.mdx
@@ -37,7 +37,7 @@ npm i -D @custom-elements-manifest/analyzer
 import { wcbStaticProps } from 'web-component-base/cem-plugin'
 
 export default {
-  globs: ['src/**/*.js'],
+  globs: ['src/**/*.{js,ts}'],
   outdir: '.',
   plugins: [wcbStaticProps()],
 }
@@ -66,11 +66,19 @@ With globs scoped to your source it should finish in well under a second.
 
 Given a component:
 
-```js
-const props = { variant: 'primary', disabled: false, maxCount: 3 }
+```ts
+type CozyButtonProps = {
+  variant: 'primary' | 'ghost'
+  disabled: boolean
+  maxCount: number
+}
 
-export class CozyButton extends WebComponent {
-  static props = props
+export class CozyButton extends WebComponent<CozyButtonProps> {
+  static props: CozyButtonProps = {
+    variant: 'primary',
+    disabled: false,
+    maxCount: 3,
+  }
   static shadowRootInit = { mode: 'open' }
   static styles = ':host { display: inline-block }'
   get template() {
@@ -92,10 +100,10 @@ customElements.define('cozy-button', CozyButton)
 
 Two details worth knowing:
 
-- **Types come from the default literal**: `true`/`false` → `boolean`, numeric → `number`, object/array → `object`, everything else → `string`.
+- **Types come from the default literal**: `true`/`false` → `boolean`, numeric → `number`, object/array → `object`, everything else → `string`. The TypeScript annotation is not consulted, so `variant`'s union still lands in the manifest as `string`.
 - **Attribute names come from wcb's own `getKebabCase`**, the same function `observedAttributes` uses, so manifest names can't drift from what the component actually observes.
 
-The defaults may be written inline or hoisted into a module-level `const`. The latter is required by the [typed props](/prop-access/#typed-props-in-typescript) pattern, and the plugin resolves it either way.
+The defaults may be written inline as above, or hoisted into a module-level `const` — the shape the inferred variant of the [typed props](/prop-access/#typed-props-in-typescript) pattern uses (`WebComponent<typeof props>`). The plugin resolves both.
 
 ## Storybook
 
@@ -170,7 +178,7 @@ import { wcbStaticProps } from 'web-component-base/cem-plugin'
 import { generateCustomData } from 'cem-plugin-vs-code-custom-data-generator'
 
 export default {
-  globs: ['src/**/*.js'],
+  globs: ['src/**/*.{js,ts}'],
   outdir: '.',
   plugins: [wcbStaticProps(), generateCustomData()],
 }

--- a/docs/src/content/docs/guides/prop-access.mdx
+++ b/docs/src/content/docs/guides/prop-access.mdx
@@ -98,11 +98,14 @@ el.toggleAttribute('flag', true) // prop syncs, component re-renders
 Enumerated attributes like `contenteditable` and `aria-*` attributes are the
 exception. They are genuine strings where `"false"` is meaningful, so declare
 them as **string** props rather than booleans. Strings serialize literally and
-are never removed, so they need nothing special at runtime; in TypeScript you
-can narrow them to the values you accept:
+are never removed, so they need nothing special at runtime; in TypeScript,
+narrow them to the values you accept in your
+[props type](#typed-props-in-typescript):
 
 ```ts
-const props = { ariaChecked: 'false' as 'true' | 'false' }
+type ToggleProps = {
+  ariaChecked: 'true' | 'false'
+}
 ```
 
 <Aside type="tip" title="Default boolean props to false">
@@ -284,15 +287,6 @@ the defaults themselves are checked against the type, so a missing key or a
 default outside the union is a compile error too.
 
 This is types-only. The runtime is unchanged, and `static strictProps` still guards writes that come in from attributes at runtime. Omitting the type argument keeps the previous untyped behavior.
-
-<Aside type="tip">
-  You can also infer the type from the defaults instead of writing it out:
-  declare them in a `const` and pass its `typeof`:
-  `class CozyButton extends WebComponent<typeof props> { static props = props }`.
-  Inferred values widen (`variant: 'primary'` types as plain `string`), so
-  narrow with a cast where it matters:
-  `variant: 'primary' as 'primary' | 'ghost'`.
-</Aside>
 
 ### Unobserved properties
 

--- a/src/cem-plugin.js
+++ b/src/cem-plugin.js
@@ -75,16 +75,13 @@ function unwrap(ts, node) {
 
 /**
  * Resolves an identifier to the object literal of a module-level `const` in
- * the same file. This is what makes the typed-props pattern work:
+ * the same file, so a component that keeps its defaults in a shared `const`
+ * still yields attributes instead of silently emitting none:
  *
  * ```js
  * const props = { variant: 'primary' }
  * class Foo extends WebComponent { static props = props }
  * ```
- *
- * A class can't reference its own static in its `extends` clause, so typed
- * components must hoist the defaults into a const — without this the whole
- * pattern would yield zero attributes.
  * @param {any} ts the TypeScript module handed to the hook
  * @param {any} node any node in the source file
  * @param {string} name the identifier to resolve

--- a/storybook/stories/prop-types.stories.js
+++ b/storybook/stories/prop-types.stories.js
@@ -15,8 +15,8 @@ export const BooleanProps = {
   args: { isInline: false, anotherone: false },
   render: ({ isInline, anotherone }) => html`
     <boolean-prop-test
-      is-inline=${isInline}
-      anotherone=${anotherone}
+      ?is-inline=${isInline}
+      ?anotherone=${anotherone}
     ></boolean-prop-test>
   `,
 }

--- a/storybook/stories/typed-button.stories.js
+++ b/storybook/stories/typed-button.stories.js
@@ -10,7 +10,7 @@ export default {
   render: ({ variant, disabled, clicks }) => html`
     <typed-button
       variant=${variant}
-      disabled=${disabled}
+      ?disabled=${disabled}
       clicks=${clicks}
     ></typed-button>
   `,


### PR DESCRIPTION
Update the 'What it produces' CozyButton example to the current
typed-props shape from the Prop Access guide: a named CozyButtonProps
type outside the class and the typed defaults object within, instead
of a hoisted module-level const. Correct the follow-up note (hoisting
is only needed for the inferred typeof-props variant), clarify that
manifest types come from the default literal rather than the TS
annotation, and widen the config globs so the TS example is matched.
