### PR TITLE
fix(demo): stabilize the WebKit nightly e2e for render-reconciliation

### DIFF
--- a/demo/examples/render-reconciliation/index.js
+++ b/demo/examples/render-reconciliation/index.js
@@ -85,11 +85,7 @@ class TransitionSafe extends WebComponent {
   // self-contained so the transition is guaranteed present wherever the
   // component is used — including the e2e spec, which loads no page CSS
   static shadowRootInit = { mode: 'open' }
-  // `:host` needs an explicit block so the box's `width: 90%` resolves against a
-  // definite containing block. Without it the host is `display: inline` (no page
-  // CSS in the e2e spec), and percentage-width resolution against an unsized
-  // inline host is engine-dependent — WebKit never grows the box, so the e2e
-  // "grew mid-transition" assertion sees the untouched 4em start width.
+
   static styles = `
     :host { display: block; }
     .anim-box {

--- a/demo/examples/render-reconciliation/index.js
+++ b/demo/examples/render-reconciliation/index.js
@@ -85,7 +85,13 @@ class TransitionSafe extends WebComponent {
   // self-contained so the transition is guaranteed present wherever the
   // component is used — including the e2e spec, which loads no page CSS
   static shadowRootInit = { mode: 'open' }
+  // `:host` needs an explicit block so the box's `width: 90%` resolves against a
+  // definite containing block. Without it the host is `display: inline` (no page
+  // CSS in the e2e spec), and percentage-width resolution against an unsized
+  // inline host is engine-dependent — WebKit never grows the box, so the e2e
+  // "grew mid-transition" assertion sees the untouched 4em start width.
   static styles = `
+    :host { display: block; }
     .anim-box {
       width: 4em;
       height: 2.5em;


### PR DESCRIPTION
## What happened

The **Nightly E2E** full-matrix job has failed since 2026-07-21 (green through 07-20). It fails on **WebKit only**, deterministically — identical failure two nights running:

```
FAIL  webkit  test/e2e/render-reconciliation.test.mjs > an unrelated re-render leaves an animating element untouched
AssertionError: expected 64 to be greater than 64
 ❯ test/e2e/render-reconciliation.test.mjs:63:36
```

Chromium and Firefox pass. It slipped through PR review because push/PR CI (`.github/workflows/test.yml`) runs the e2e suite **Chromium-only**; the three-engine matrix runs only in the nightly — exactly the gap the nightly exists to cover.

## It is not a library bug

The test's real invariant — an unrelated re-render leaves the animating element untouched — holds on every engine. Verified by tracing the reconciler and with a happy-dom probe:

- The `#box` element is reused across the unrelated `ticks` re-renders (`patchNode` `sameTag` path); the element-identity assertion (line 61) passes even on WebKit.
- The `wide` class is applied once on flip, then `patchProps`' `Object.is` check skips re-applying it — the ticks loop produced **zero** further class mutations, so a running transition is never disturbed.

The failing assertion is line 63, which is the fixture's proxy for "the transition is visibly progressing." That depends on `.anim-box.wide { width: 90% }` resolving against the host. The e2e spec loads no page CSS and `:host` set no width, so the host is `display: inline`. Percentage-width resolution against an unsized inline host is engine-dependent, and WebKit never grows the box — so it is measured at exactly its `4em`/64px start width.

## The change

Add `:host { display: block }` to `TransitionSafe.styles` in `demo/examples/render-reconciliation/index.js` so `90%` resolves against a definite containing block on all three engines. This keeps the test's intent intact and fixes the fixture, not the assertion.

## Testing

- `pnpm test` (unit, happy-dom): 144 passed.
- The three-engine e2e matrix could **not** be run in this environment (WebKit/Chromium Playwright builds can't be downloaded here). Please confirm the green via a manual `workflow_dispatch` of the Nightly E2E workflow, or let the next scheduled nightly verify.
