### PR TITLE
docs: correct stale Library Size figures

### DIFF
--- a/docs/src/content/docs/guides/library-size.md
+++ b/docs/src/content/docs/guides/library-size.md
@@ -5,6 +5,6 @@ slug: library-size
 
 All the functions and the base class in the library are minimalist by design and only contains what is needed for their purpose.
 
-The main export (with `WebComponent` + `html`) is **1.7 kB** (min + gzip) according to [bundlephobia.com](https://bundlephobia.com/package/web-component-base@latest), and the `WebComponent` base class is **1.96 kB** (min + brotli) according to [size-limit](http://github.com/ai/size-limit).
+The `WebComponent` base class is **2.01 kB** (min + brotli) according to [size-limit](http://github.com/ai/size-limit).
 
 Every change that moves this number is recorded in [`size-change-log.md`](https://github.com/ayo-run/wcb/blob/main/size-change-log.md), with the reason the bytes were spent and the benefit they bought.


### PR DESCRIPTION
The Library Size guide claimed the main export was 1.7 kB (min+gzip) per
bundlephobia and the WebComponent base class 1.96 kB (min+brotli) per
size-limit. Both are stale: the Phase 0 correctness work (recorded in
size-change-log.md) grew the base class from a 1.19 kB baseline to a
size-limit-measured 2.01 kB.

Drop the unverifiable bundlephobia gzip figure and keep only the number
the repo's own tooling measures, corrected to 2.01 kB (min+brotli).
