### PR TITLE
docs(demo): add the library-comparison counter demo

### DIFF
--- a/demo/examples/library-comparison/README.md
+++ b/demo/examples/library-comparison/README.md
@@ -1,0 +1,29 @@
+# Library comparison
+
+The counter component from the [comparison guide](https://webcomponent.io/comparison/),
+implemented in each library it's measured against, plus the reproducible size
+benchmark behind the guide's numbers.
+
+- `counters/*.mjs` — the same minimal counter (one reactive `count` prop, a
+  click handler, a re-render on change) in `web-component-base`, Elena, Lit,
+  FAST, and vanilla `HTMLElement`. `index.html` runs all five live.
+- `measure.mjs` — bundles each counter _with_ its library runtime (esbuild,
+  `--bundle --minify --format=esm`) and compresses the result with gzip (−9) and
+  brotli (q11) via Node's `zlib`. That's the real "cost of your first
+  component": library runtime + component code, everything the browser
+  downloads.
+
+## Run the benchmark
+
+From this folder:
+
+```sh
+node measure.mjs          # human-readable table
+node measure.mjs --md     # Markdown table (what the guide embeds)
+node measure.mjs --json   # raw numbers
+```
+
+The external libraries are pinned dev dependencies of the `demo` workspace, and
+`web-component-base` is bundled from its published `dist/` (run `pnpm build` at
+the repo root first), so the numbers are deterministic. Bump a pinned version in
+`demo/package.json`, re-run, and the table moves with it.

--- a/demo/examples/library-comparison/counters/elena.mjs
+++ b/demo/examples/library-comparison/counters/elena.mjs
@@ -1,0 +1,24 @@
+// The same reactive counter, written in Elena (@elenajs/core).
+// Elena renders HTML first and progressively enhances, so the click handler is
+// wired up in `firstUpdated` rather than inline in the template. `count` is a
+// non-reflected reactive prop.
+import { Elena, html } from '@elenajs/core'
+
+export class ElenaCounter extends Elena(HTMLElement) {
+  static tagName = 'elena-counter'
+  static props = [{ name: 'count', reflect: false }]
+
+  count = 0
+
+  render() {
+    return html`<button type="button">${this.count}</button>`
+  }
+
+  firstUpdated() {
+    this.element.addEventListener('click', () => {
+      this.count++
+    })
+  }
+}
+
+ElenaCounter.define()

--- a/demo/examples/library-comparison/counters/elena.mjs
+++ b/demo/examples/library-comparison/counters/elena.mjs
@@ -1,7 +1,7 @@
 // The same reactive counter, written in Elena (@elenajs/core).
-// Elena renders HTML first and progressively enhances, so the click handler is
-// wired up in `firstUpdated` rather than inline in the template. `count` is a
-// non-reflected reactive prop.
+// Elena's `html` has no inline event syntax, so the click handler is attached
+// in `firstUpdated` (after the first render) rather than in the template.
+// `count` is a non-reflected reactive prop.
 import { Elena, html } from '@elenajs/core'
 
 export class ElenaCounter extends Elena(HTMLElement) {

--- a/demo/examples/library-comparison/counters/fast.mjs
+++ b/demo/examples/library-comparison/counters/fast.mjs
@@ -1,0 +1,25 @@
+// The same reactive counter, written in FAST (@microsoft/fast-element).
+// The buildless, non-decorator form: the template binds against the element
+// instance (`x`), and `count` is declared as a number attribute.
+import {
+  FASTElement,
+  html,
+  nullableNumberConverter,
+} from '@microsoft/fast-element'
+
+const template = html`
+  <button @click=${(x) => x.count++}>${(x) => x.count}</button>
+`
+
+export class FastCounter extends FASTElement {
+  constructor() {
+    super()
+    this.count = 0
+  }
+}
+
+FastCounter.define({
+  name: 'fast-counter',
+  template,
+  attributes: [{ property: 'count', converter: nullableNumberConverter }],
+})

--- a/demo/examples/library-comparison/counters/lit.mjs
+++ b/demo/examples/library-comparison/counters/lit.mjs
@@ -1,0 +1,17 @@
+// The same reactive counter, written in Lit.
+import { LitElement, html } from 'lit'
+
+export class LitCounter extends LitElement {
+  static properties = { count: { type: Number } }
+
+  constructor() {
+    super()
+    this.count = 0
+  }
+
+  render() {
+    return html`<button @click=${() => this.count++}>${this.count}</button>`
+  }
+}
+
+customElements.define('lit-counter', LitCounter)

--- a/demo/examples/library-comparison/counters/vanilla.mjs
+++ b/demo/examples/library-comparison/counters/vanilla.mjs
@@ -1,0 +1,33 @@
+// The same reactive counter, written from scratch on top of HTMLElement — the
+// baseline every library above is measured against. No library runtime: the
+// reactivity, the attribute reflection, and the re-render are all hand-rolled.
+export class VanillaCounter extends HTMLElement {
+  static observedAttributes = ['count']
+
+  connectedCallback() {
+    if (!this.hasAttribute('count')) this.setAttribute('count', '0')
+    this.render()
+    this.addEventListener('click', () => {
+      this.setAttribute('count', String(this.count + 1))
+    })
+  }
+
+  attributeChangedCallback() {
+    this.render()
+  }
+
+  get count() {
+    return Number(this.getAttribute('count')) || 0
+  }
+
+  render() {
+    let button = this.querySelector('button')
+    if (!button) {
+      button = document.createElement('button')
+      this.append(button)
+    }
+    button.textContent = String(this.count)
+  }
+}
+
+customElements.define('vanilla-counter', VanillaCounter)

--- a/demo/examples/library-comparison/counters/wcb.mjs
+++ b/demo/examples/library-comparison/counters/wcb.mjs
@@ -1,0 +1,15 @@
+// The same reactive counter, written in web-component-base.
+// One reactive `count` prop, a click handler, a re-render on change.
+import { WebComponent, html } from 'web-component-base'
+
+export class WcbCounter extends WebComponent {
+  static props = { count: 0 }
+
+  get template() {
+    return html`
+      <button onClick=${() => ++this.props.count}>${this.props.count}</button>
+    `
+  }
+}
+
+customElements.define('wcb-counter', WcbCounter)

--- a/demo/examples/library-comparison/index.html
+++ b/demo/examples/library-comparison/index.html
@@ -106,7 +106,7 @@
         <span class="lib">Elena</span>
         <span class="size"><strong>3.4 kB</strong> brotli</span>
         <elena-counter></elena-counter>
-        <figcaption>progressive enhancement in <code>firstUpdated</code></figcaption>
+        <figcaption>click handler wired in <code>firstUpdated</code></figcaption>
       </figure>
       <figure class="counter-card">
         <span class="lib">Lit</span>

--- a/demo/examples/library-comparison/index.html
+++ b/demo/examples/library-comparison/index.html
@@ -1,0 +1,231 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Library comparison — the same counter, measured</title>
+    <script type="module" src="./counters/vanilla.mjs"></script>
+    <script type="module" src="./counters/wcb.mjs"></script>
+    <script type="module" src="./counters/elena.mjs"></script>
+    <script type="module" src="./counters/lit.mjs"></script>
+    <script type="module" src="./counters/fast.mjs"></script>
+    <script>try{document.documentElement.dataset.theme=localStorage.getItem('wcb-theme')||(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light')}catch(e){}</script>
+    <link rel="stylesheet" href="../../shell.css" />
+    <script type="module" src="../../shell.js"></script>
+    <style>
+      .counters {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+        gap: 1em;
+        margin: 1.5em 0;
+      }
+      .counter-card {
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        background: var(--card);
+        padding: 1em;
+        display: flex;
+        flex-direction: column;
+        gap: 0.6em;
+      }
+      .counter-card .lib {
+        font-weight: 600;
+      }
+      .counter-card .size {
+        font-size: 0.85em;
+        color: var(--muted);
+      }
+      .counter-card .size strong {
+        color: var(--accent);
+      }
+      .counter-card button {
+        font-size: 1.4em;
+        padding: 0.3em 0.8em;
+        min-width: 3em;
+      }
+      .win {
+        color: var(--accent);
+        font-weight: 600;
+      }
+      figcaption {
+        color: var(--muted);
+        font-size: 0.9em;
+        margin-top: 0.4em;
+      }
+      table.sizes {
+        border-collapse: collapse;
+        width: 100%;
+        margin: 1em 0;
+      }
+      table.sizes th,
+      table.sizes td {
+        border: 1px solid var(--border);
+        padding: 0.5em 0.75em;
+        text-align: right;
+      }
+      table.sizes th:first-child,
+      table.sizes td:first-child {
+        text-align: left;
+      }
+      table.sizes thead th {
+        background: var(--tag);
+      }
+      table.sizes tbody tr:first-child {
+        font-weight: 600;
+      }
+      .repro {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4em;
+        align-items: baseline;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>The same counter, in each library</h1>
+    <p>
+      This is the component behind the
+      <a href="https://webcomponent.io/comparison/">comparison guide</a>: one
+      minimal counter — a single reactive <code>count</code> prop, a click
+      handler, a re-render on change — implemented in
+      <code>web-component-base</code> and in each library it's measured against.
+      Every counter below is live; click it. The source of each is listed at
+      the bottom of the page, and the
+      <a href="#methodology">measurement that produces the sizes</a> is
+      <code>measure.mjs</code>, runnable from this folder.
+    </p>
+
+    <div class="counters">
+      <figure class="counter-card">
+        <span class="lib">web-component-base</span>
+        <span class="size"><strong>2.6 kB</strong> brotli</span>
+        <wcb-counter></wcb-counter>
+        <figcaption><code>static props</code> + <code>html</code></figcaption>
+      </figure>
+      <figure class="counter-card">
+        <span class="lib">Elena</span>
+        <span class="size"><strong>3.4 kB</strong> brotli</span>
+        <elena-counter></elena-counter>
+        <figcaption>progressive enhancement in <code>firstUpdated</code></figcaption>
+      </figure>
+      <figure class="counter-card">
+        <span class="lib">Lit</span>
+        <span class="size"><strong>5.3 kB</strong> brotli</span>
+        <lit-counter></lit-counter>
+        <figcaption><code>static properties</code>, shadow DOM</figcaption>
+      </figure>
+      <figure class="counter-card">
+        <span class="lib">FAST</span>
+        <span class="size"><strong>12.2 kB</strong> brotli</span>
+        <fast-counter></fast-counter>
+        <figcaption>binding directives, shadow DOM</figcaption>
+      </figure>
+      <figure class="counter-card">
+        <span class="lib">vanilla <code>HTMLElement</code></span>
+        <span class="size"><strong>~0.2 kB</strong> brotli</span>
+        <vanilla-counter></vanilla-counter>
+        <figcaption>no library — the hand-rolled baseline</figcaption>
+      </figure>
+    </div>
+
+    <h2 id="methodology">How it's measured</h2>
+    <p>
+      The number that matters for a first component is not the library's
+      advertised size — it's <strong>library runtime + your component code,
+      bundled and compressed</strong>, because that's everything the browser
+      actually downloads. So <code>measure.mjs</code>, for each library:
+    </p>
+    <ol>
+      <li>
+        bundles the counter <em>with</em> its library runtime using
+        <code>esbuild</code> (<code>bundle: true</code>,
+        <code>minify: true</code>, <code>format: 'esm'</code>) — tree-shaking
+        away whatever that component doesn't touch;
+      </li>
+      <li>
+        compresses the bundle with <strong>gzip</strong> (level 9) and
+        <strong>brotli</strong> (quality 11) via Node's built-in
+        <code>zlib</code> — the same codecs a CDN or server serves with.
+      </li>
+    </ol>
+    <p>
+      The counters are byte-for-byte the same components running above and
+      listed under Implementation below. The external libraries are pinned dev
+      dependencies of this demo workspace, and <code>web-component-base</code>
+      is bundled from its published <code>dist/</code>, so the run is
+      deterministic.
+    </p>
+
+    <h2>Output</h2>
+    <p>
+      Measured at the pinned versions below (WCB from this repo's build,
+      esbuild <code>0.27</code>, Node <code>zlib</code>):
+    </p>
+    <table class="sizes">
+      <thead>
+        <tr>
+          <th>Library</th>
+          <th>Version</th>
+          <th>Minified</th>
+          <th>Gzip</th>
+          <th>Brotli</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>web-component-base</td>
+          <td>6.1.1</td>
+          <td>6.7 kB</td>
+          <td>2.9 kB</td>
+          <td>2.6 kB</td>
+        </tr>
+        <tr>
+          <td>@elenajs/core</td>
+          <td>1.0.0</td>
+          <td>9.1 kB</td>
+          <td>3.7 kB</td>
+          <td>3.4 kB</td>
+        </tr>
+        <tr>
+          <td>lit</td>
+          <td>3.3.3</td>
+          <td>15.3 kB</td>
+          <td>5.9 kB</td>
+          <td>5.3 kB</td>
+        </tr>
+        <tr>
+          <td>@microsoft/fast-element</td>
+          <td>3.0.1</td>
+          <td>44.8 kB</td>
+          <td>13.6 kB</td>
+          <td>12.2 kB</td>
+        </tr>
+        <tr>
+          <td>vanilla <code>HTMLElement</code></td>
+          <td>—</td>
+          <td>0.6 kB</td>
+          <td>0.3 kB</td>
+          <td>0.2 kB</td>
+        </tr>
+      </tbody>
+    </table>
+    <p>
+      The WCB counter is the smallest real component here — about
+      <strong>21% under Elena, 51% under Lit, and 79% under FAST</strong> once
+      compressed.
+    </p>
+
+    <h2>Reproduce it</h2>
+    <p class="repro">
+      From <code>demo/examples/library-comparison/</code>:
+      <code>node measure.mjs</code> for the table,
+      <code>node measure.mjs --md</code> for Markdown, or
+      <code>node measure.mjs --json</code> for raw numbers.
+    </p>
+    <p>
+      Bump a pinned version in <code>demo/package.json</code>, re-run, and the
+      numbers move with it — the benchmark is the source of truth, not this
+      page.
+    </p>
+  </body>
+</html>

--- a/demo/examples/library-comparison/measure.mjs
+++ b/demo/examples/library-comparison/measure.mjs
@@ -1,0 +1,125 @@
+// Reproducible size benchmark behind the comparison guide's numbers.
+//
+// For each library it bundles the *same* counter component
+// (`counters/<lib>.mjs`) together with that library's runtime, minifies with
+// esbuild, and compresses the result with gzip (level 9) and brotli (quality
+// 11) using Node's built-in zlib. That is the real "cost of your first
+// component": everything the browser downloads for one reactive element.
+//
+//   node measure.mjs            # human-readable table
+//   node measure.mjs --md       # a Markdown table (what the guide embeds)
+//   node measure.mjs --json     # machine-readable JSON
+//
+// The external libraries are pinned dev dependencies of this demo workspace, so
+// the run is deterministic; `web-component-base` is bundled from its published
+// build output (`dist/`) rather than the workspace source, to measure exactly
+// what consumers install.
+import { build } from 'esbuild'
+import { gzipSync, brotliCompressSync, constants } from 'node:zlib'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { readFileSync } from 'node:fs'
+import process from 'node:process'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const demoRoot = resolve(here, '../..')
+
+// Resolve `web-component-base` to its built entry (the published artifact), not
+// the workspace `src/` the Vite dev server aliases it to.
+const wcbDist = resolve(here, '../../../dist/index.js')
+const wcbAlias = {
+  name: 'wcb-dist',
+  setup(b) {
+    b.onResolve({ filter: /^web-component-base$/ }, () => ({ path: wcbDist }))
+  },
+}
+
+// Not every library exposes `./package.json` in its `exports` map, so read the
+// installed manifest straight from the demo's `node_modules`.
+const version = (pkg) =>
+  JSON.parse(
+    readFileSync(resolve(demoRoot, 'node_modules', pkg, 'package.json'), 'utf8')
+  ).version
+
+const wcbVersion = JSON.parse(
+  readFileSync(resolve(here, '../../../package.json'), 'utf8')
+).version
+
+const targets = [
+  { name: 'web-component-base', file: 'wcb.mjs', version: wcbVersion },
+  {
+    name: '@elenajs/core',
+    file: 'elena.mjs',
+    version: version('@elenajs/core'),
+  },
+  { name: 'lit', file: 'lit.mjs', version: version('lit') },
+  {
+    name: '@microsoft/fast-element',
+    file: 'fast.mjs',
+    version: version('@microsoft/fast-element'),
+  },
+  { name: 'vanilla HTMLElement', file: 'vanilla.mjs', version: '-' },
+]
+
+const gzip = (buf) => gzipSync(buf, { level: 9 }).length
+const brotli = (buf) =>
+  brotliCompressSync(buf, {
+    params: { [constants.BROTLI_PARAM_QUALITY]: 11 },
+  }).length
+
+const kb = (n) => (n / 1000).toFixed(1) + ' kB'
+
+const rows = []
+for (const t of targets) {
+  const result = await build({
+    entryPoints: [resolve(here, 'counters', t.file)],
+    bundle: true,
+    minify: true,
+    format: 'esm',
+    write: false,
+    plugins: [wcbAlias],
+    logLevel: 'silent',
+  })
+  const code = result.outputFiles[0].contents
+  rows.push({
+    name: t.name,
+    version: t.version,
+    minified: code.length,
+    gzip: gzip(code),
+    brotli: brotli(code),
+  })
+}
+
+const arg = process.argv[2]
+
+if (arg === '--json') {
+  console.log(JSON.stringify(rows, null, 2))
+} else if (arg === '--md') {
+  console.log('| Library | Version | Minified | Gzip | Brotli |')
+  console.log('| ------- | ------- | -------- | ---- | ------ |')
+  for (const r of rows) {
+    console.log(
+      `| ${r.name} | ${r.version} | ${kb(r.minified)} | ${kb(r.gzip)} | ${kb(r.brotli)} |`
+    )
+  }
+} else {
+  const pad = (s, n) => String(s).padEnd(n)
+  const lpad = (s, n) => String(s).padStart(n)
+  console.log(
+    pad('Library', 26),
+    pad('Version', 9),
+    lpad('Minified', 10),
+    lpad('Gzip', 8),
+    lpad('Brotli', 8)
+  )
+  console.log('-'.repeat(63))
+  for (const r of rows) {
+    console.log(
+      pad(r.name, 26),
+      pad(r.version, 9),
+      lpad(kb(r.minified), 10),
+      lpad(kb(r.gzip), 8),
+      lpad(kb(r.brotli), 8)
+    )
+  }
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -25,6 +25,20 @@
       </p>
     </header>
 
+    <h2 class="section-label">Library comparison</h2>
+    <div class="grid">
+      <a class="card" href="./examples/library-comparison/index.html">
+        <div class="name">
+          The same counter, measured<span class="tag">sizes</span>
+        </div>
+        <div class="desc">
+          One counter in WCB, Elena, Lit, FAST, and vanilla — live side by side,
+          with the reproducible <code>measure.mjs</code> behind the comparison
+          guide's numbers.
+        </div>
+      </a>
+    </div>
+
     <h2 class="section-label">v6 behavior demos</h2>
     <div class="grid">
       <a class="card" href="./examples/boolean-props/index.html">

--- a/demo/package.json
+++ b/demo/package.json
@@ -14,6 +14,10 @@
     "web-component-base": "workspace:*"
   },
   "devDependencies": {
+    "@elenajs/core": "1.0.0",
+    "@microsoft/fast-element": "3.0.1",
+    "esbuild": "^0.27.2",
+    "lit": "3.3.3",
     "vite": "^7.3.1"
   }
 }

--- a/docs/src/content/docs/guides/comparison.md
+++ b/docs/src/content/docs/guides/comparison.md
@@ -11,6 +11,8 @@ This page puts these benefits and their cost in context: how much does WCB weigh
 
 Numbers below are **measured** from the same minimal counter component (one reactive `count` prop, a click handler, a re-render on change) written in each library, bundled with `esbuild --bundle --minify --format=esm`, and compressed with gzip (level 9) and brotli (quality 11). This is the real "cost of your first component": library runtime + component code, everything the browser downloads.
 
+See it live: [Library comparison demo ↗](https://demo.webcomponent.io/examples/library-comparison/) — every counter running side by side, the source of each, and the `measure.mjs` script that produces the table below.
+
 | Library                   | Version | Minified | Gzip    | Brotli     |
 | ------------------------- | ------- | -------- | ------- | ---------- |
 | **web-component-base**    | 6.1.0   | 6.7 kB   | 2.9 kB  | **2.6 kB** |
@@ -49,4 +51,4 @@ For what these numbers and capabilities add up to (and when they don't) see [Why
 
 ---
 
-_WCB re-measured 2026-07-20 at v6.1.0; the other libraries measured 2026-07-19, with esbuild, Node zlib (gzip −9, brotli q11), at the pinned versions above. Methodology: identical counter component per library, bundled per library, compressed. Re-run them yourself. The benchmark is trivially reproducible with the versions pinned above._
+_WCB re-measured 2026-07-20 at v6.1.0; the other libraries measured 2026-07-19, with esbuild, Node zlib (gzip −9, brotli q11), at the pinned versions above. Methodology: identical counter component per library, bundled per library, compressed. Re-run them yourself — the counters and the [`measure.mjs`](https://demo.webcomponent.io/examples/library-comparison/) script live in the demo workspace (`demo/examples/library-comparison/`). The benchmark is trivially reproducible with the versions pinned above._

--- a/docs/src/content/docs/guides/comparison.md
+++ b/docs/src/content/docs/guides/comparison.md
@@ -37,14 +37,14 @@ What each library gives you beyond extending directly from `HTMLElement`, the bo
 | Keyed list reconciliation        | ⚠️ positional                                                      | ✅ `repeat` directive                                    | ❌                                      | ✅ `repeat` with recycling controls              |
 | Light DOM by default             | ✅ (shadow DOM opt-in via `static shadowRootInit`)                 | ❌ shadow DOM by default                                 | ✅ (shadow opt-in)                      | ❌ shadow DOM by default                         |
 | Scoped styles                    | ✅ `static styles` + constructable stylesheets (needs shadow root) | ✅ shadow-scoped CSS                                     | ✅ scoped without shadow DOM            | ✅ shadow-scoped + design tokens                 |
-| SSR / hydration story            | ✅ attribute-driven state renders from any server                  | ✅ `@lit-labs/ssr` + hydration                           | ✅ HTML/CSS-first, server utilities     | ⚠️ experimental SSR                              |
+| SSR / hydration story            | ✅ attribute-driven state renders from any server                  | ✅ `@lit-labs/ssr` + hydration                           | ✅ server-rendered markup + hydration utilities | ⚠️ experimental SSR                              |
 | Works with zero build tooling    | ✅ import from CDN, no compiler                                    | ✅ (buildless possible, decorators need tooling)         | ✅                                      | ⚠️ practical with tooling                        |
 | Editor/IDE tooling               | ✅ typed props + [CEM analyzer plugin](/cem-plugin/)               | ✅ extensive (analyzer, TS decorators, IDE plugins)      | ✅ CEM-focused                          | ✅ TS-first                                      |
 | Lifecycle hooks                  | `onInit`, `afterViewInit`, `onChanges`, `onDestroy`                | full reactive update lifecycle                           | `willUpdate`, `firstUpdated`, `updated` | full lifecycle + behaviors                       |
-| Backing / ecosystem              | solo maintainer, small surface                                     | Google, huge ecosystem                                   | new (2026), design-system focus         | Microsoft, powers Fluent UI                      |
+| Backing / ecosystem              | solo maintainer, small surface                                     | Google, large ecosystem                                   | new (2026), solo-authored         | Microsoft, powers Fluent UI                      |
 
 :::note[Why 11ty WebC isn't here]
-WebC is a compile-time tool: it resolves components during an Eleventy build and ships plain HTML with no client runtime. Every row above is about what a library does _in the browser at runtime_, so a side-by-side comparison would be measuring two different things. If your components are static at build time, WebC solves a different problem, and solves it well.
+WebC is a compile-time tool: it resolves components during an Eleventy build and ships plain HTML with no client runtime. Every row above is about what a library does _in the browser at runtime_, so a side-by-side comparison would be measuring two different things. If your components are static at build time, WebC solves a different problem.
 :::
 
 For what these numbers and capabilities add up to (and when they don't) see [Why would anyone use WCB?](/why/).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,10 +34,10 @@ importers:
         version: 0.27.2
       eslint:
         specifier: ^9.39.2
-        version: 9.39.2(jiti@2.6.1)(supports-color@10.2.2)
+        version: 9.39.2(jiti@2.6.1)
       eslint-plugin-jsdoc:
         specifier: ^62.4.1
-        version: 62.4.1(eslint@9.39.2(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 62.4.1(eslint@9.39.2(jiti@2.6.1))
       globals:
         specifier: ^17.1.0
         version: 17.1.0
@@ -55,7 +55,7 @@ importers:
         version: 17.0.8
       netlify-cli:
         specifier: ^23.13.5
-        version: 23.13.5(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))(picomatch@4.0.4)(rollup@4.60.3)(supports-color@10.2.2)
+        version: 23.13.5(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0)(picomatch@4.0.4)(rollup@4.60.3)
       playwright:
         specifier: ^1.61.1
         version: 1.61.1
@@ -64,13 +64,13 @@ importers:
         version: 3.8.1
       release-it:
         specifier: ^19.2.4
-        version: 19.2.4(@types/node@25.0.10)(magicast@0.5.2)(supports-color@10.2.2)
+        version: 19.2.4(@types/node@25.0.10)(magicast@0.5.2)
       simple-git:
         specifier: ^3.36.0
-        version: 3.36.0(supports-color@10.2.2)
+        version: 3.36.0
       simple-server:
         specifier: ^1.1.1
-        version: 1.1.1(supports-color@10.2.2)
+        version: 1.1.1
       size-limit:
         specifier: ^12.0.0
         version: 12.0.0(jiti@2.6.1)
@@ -92,6 +92,18 @@ importers:
         specifier: workspace:*
         version: link:..
     devDependencies:
+      '@elenajs/core':
+        specifier: 1.0.0
+        version: 1.0.0
+      '@microsoft/fast-element':
+        specifier: 3.0.1
+        version: 3.0.1
+      esbuild:
+        specifier: ^0.27.2
+        version: 0.27.7
+      lit:
+        specifier: 3.3.3
+        version: 3.3.3
       vite:
         specifier: ^7.3.1
         version: 7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)
@@ -100,10 +112,10 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.39.1
-        version: 0.39.1(astro@6.3.1(@netlify/blobs@10.5.0(supports-color@10.2.2))(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))(jiti@2.6.1)(rollup@4.60.3)(supports-color@10.2.2)(terser@5.39.0)(yaml@2.9.0))(supports-color@10.2.2)(typescript@5.9.3)
+        version: 0.39.1(astro@6.3.1(@netlify/blobs@10.5.0)(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0)(jiti@2.6.1)(rollup@4.60.3)(terser@5.39.0)(yaml@2.9.0))(typescript@5.9.3)
       astro:
         specifier: ^6.3.1
-        version: 6.3.1(@netlify/blobs@10.5.0(supports-color@10.2.2))(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))(jiti@2.6.1)(rollup@4.60.3)(supports-color@10.2.2)(terser@5.39.0)(yaml@2.9.0)
+        version: 6.3.1(@netlify/blobs@10.5.0)(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0)(jiti@2.6.1)(rollup@4.60.3)(terser@5.39.0)(yaml@2.9.0)
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -119,10 +131,10 @@ importers:
         version: 0.11.0
       '@storybook/addon-docs':
         specifier: ^9.1.15
-        version: 9.1.20(@types/react@19.2.17)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))
+        version: 9.1.20(@types/react@19.2.17)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))
       '@storybook/web-components-vite':
         specifier: ^9.1.15
-        version: 9.1.20(lit@3.3.3)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
+        version: 9.1.20(lit@3.3.3)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
       cem-plugin-vs-code-custom-data-generator:
         specifier: ^1.4.2
         version: 1.4.2
@@ -131,7 +143,7 @@ importers:
         version: 3.3.3
       storybook:
         specifier: ^9.1.15
-        version: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
+        version: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
       vite:
         specifier: ^7.3.1
         version: 7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)
@@ -265,6 +277,9 @@ packages:
   '@dependents/detective-less@5.0.1':
     resolution: {integrity: sha512-Y6+WUMsTFWE5jb20IFP4YGa5IrGY/+a/FbOSjDF/wz9gepU2hwCYSXRHP/vPwBvwcY3SVMASt4yXxbXNXigmZQ==}
     engines: {node: '>=18'}
+
+  '@elenajs/core@1.0.0':
+    resolution: {integrity: sha512-YOlSv7qpvVVrzlVYoyx7s1c8cBML0b5Q8WhxXaNeO3Awd2iNcf9HcJKDWuOi9KT53F7L8K9uQNLCzyb7EVxlpw==}
 
   '@emnapi/core@1.11.2':
     resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
@@ -1211,6 +1226,9 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  '@microsoft/fast-element@3.0.1':
+    resolution: {integrity: sha512-euVlL8v7EAnkYD9gf6xhnY+XgzCkD0hHwC0MVsUVyhnKfGGhrNyBeD5kYnBOCcJ9afL2jTQoOA+oOpLEty3s+A==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -7865,7 +7883,7 @@ snapshots:
     dependencies:
       picomatch: 4.0.4
 
-  '@astrojs/markdown-remark@7.1.1(supports-color@10.2.2)':
+  '@astrojs/markdown-remark@7.1.1':
     dependencies:
       '@astrojs/internal-helpers': 0.9.0
       '@astrojs/prism': 4.0.1
@@ -7876,8 +7894,8 @@ snapshots:
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
-      remark-gfm: 4.0.1(supports-color@10.2.2)
-      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
       retext-smartypants: 6.2.0
@@ -7891,18 +7909,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.4(astro@6.3.1(@netlify/blobs@10.5.0(supports-color@10.2.2))(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))(jiti@2.6.1)(rollup@4.60.3)(supports-color@10.2.2)(terser@5.39.0)(yaml@2.9.0))(supports-color@10.2.2)':
+  '@astrojs/mdx@5.0.4(astro@6.3.1(@netlify/blobs@10.5.0)(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0)(jiti@2.6.1)(rollup@4.60.3)(terser@5.39.0)(yaml@2.9.0))':
     dependencies:
-      '@astrojs/markdown-remark': 7.1.1(supports-color@10.2.2)
-      '@mdx-js/mdx': 3.1.1(supports-color@10.2.2)
+      '@astrojs/markdown-remark': 7.1.1
+      '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.3.1(@netlify/blobs@10.5.0(supports-color@10.2.2))(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))(jiti@2.6.1)(rollup@4.60.3)(supports-color@10.2.2)(terser@5.39.0)(yaml@2.9.0)
+      astro: 6.3.1(@netlify/blobs@10.5.0)(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0)(jiti@2.6.1)(rollup@4.60.3)(terser@5.39.0)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
       piccolore: 0.1.3
       rehype-raw: 7.0.0
-      remark-gfm: 4.0.1(supports-color@10.2.2)
+      remark-gfm: 4.0.1
       remark-smartypants: 3.0.2
       source-map: 0.7.6
       unist-util-visit: 5.1.0
@@ -7920,17 +7938,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  '@astrojs/starlight@0.39.1(astro@6.3.1(@netlify/blobs@10.5.0(supports-color@10.2.2))(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))(jiti@2.6.1)(rollup@4.60.3)(supports-color@10.2.2)(terser@5.39.0)(yaml@2.9.0))(supports-color@10.2.2)(typescript@5.9.3)':
+  '@astrojs/starlight@0.39.1(astro@6.3.1(@netlify/blobs@10.5.0)(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0)(jiti@2.6.1)(rollup@4.60.3)(terser@5.39.0)(yaml@2.9.0))(typescript@5.9.3)':
     dependencies:
-      '@astrojs/markdown-remark': 7.1.1(supports-color@10.2.2)
-      '@astrojs/mdx': 5.0.4(astro@6.3.1(@netlify/blobs@10.5.0(supports-color@10.2.2))(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))(jiti@2.6.1)(rollup@4.60.3)(supports-color@10.2.2)(terser@5.39.0)(yaml@2.9.0))(supports-color@10.2.2)
+      '@astrojs/markdown-remark': 7.1.1
+      '@astrojs/mdx': 5.0.4(astro@6.3.1(@netlify/blobs@10.5.0)(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0)(jiti@2.6.1)(rollup@4.60.3)(terser@5.39.0)(yaml@2.9.0))
       '@astrojs/sitemap': 3.7.2
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.3.1(@netlify/blobs@10.5.0(supports-color@10.2.2))(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))(jiti@2.6.1)(rollup@4.60.3)(supports-color@10.2.2)(terser@5.39.0)(yaml@2.9.0)
-      astro-expressive-code: 0.42.0(astro@6.3.1(@netlify/blobs@10.5.0(supports-color@10.2.2))(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))(jiti@2.6.1)(rollup@4.60.3)(supports-color@10.2.2)(terser@5.39.0)(yaml@2.9.0))
+      astro: 6.3.1(@netlify/blobs@10.5.0)(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0)(jiti@2.6.1)(rollup@4.60.3)(terser@5.39.0)(yaml@2.9.0)
+      astro-expressive-code: 0.42.0(astro@6.3.1(@netlify/blobs@10.5.0)(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0)(jiti@2.6.1)(rollup@4.60.3)(terser@5.39.0)(yaml@2.9.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -7940,13 +7958,13 @@ snapshots:
       js-yaml: 4.1.1
       klona: 2.0.6
       magic-string: 0.30.21
-      mdast-util-directive: 3.1.0(supports-color@10.2.2)
+      mdast-util-directive: 3.1.0
       mdast-util-to-markdown: 2.1.2
       mdast-util-to-string: 4.0.0
       pagefind: 1.5.2
       rehype: 13.0.2
       rehype-format: 5.0.1
-      remark-directive: 4.0.0(supports-color@10.2.2)
+      remark-directive: 4.0.0
       ultrahtml: 1.6.0
       unified: 11.0.5
       unist-util-visit: 5.1.0
@@ -8077,6 +8095,8 @@ snapshots:
     dependencies:
       gonzales-pe: 4.3.0
       node-source-walk: 7.0.1
+
+  '@elenajs/core@1.0.0': {}
 
   '@emnapi/core@1.11.2':
     dependencies:
@@ -8348,14 +8368,14 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1)(supports-color@10.2.2))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)(supports-color@10.2.2)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.1(supports-color@10.2.2)':
+  '@eslint/config-array@0.21.1':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@10.2.2)
@@ -8371,7 +8391,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.3(supports-color@10.2.2)':
+  '@eslint/eslintrc@3.3.3':
     dependencies:
       ajv: 6.12.6
       debug: 4.4.3(supports-color@10.2.2)
@@ -8740,7 +8760,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kwsites/file-exists@1.1.1(supports-color@10.2.2)':
+  '@kwsites/file-exists@1.1.1':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -8769,7 +8789,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@mdx-js/mdx@3.1.1(supports-color@10.2.2)':
+  '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -8781,14 +8801,14 @@ snapshots:
       estree-util-is-identifier-name: 3.0.0
       estree-util-scope: 1.0.0
       estree-walker: 3.0.3
-      hast-util-to-jsx-runtime: 2.3.6(supports-color@10.2.2)
+      hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
       recma-jsx: 1.0.1(acorn@8.16.0)
       recma-stringify: 1.0.0
-      rehype-recma: 1.0.0(supports-color@10.2.2)
-      remark-mdx: 3.1.1(supports-color@10.2.2)
-      remark-parse: 11.0.0(supports-color@10.2.2)
+      rehype-recma: 1.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
       remark-rehype: 11.1.2
       source-map: 0.7.6
       unified: 11.0.5
@@ -8804,6 +8824,8 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.17
       react: 19.2.7
+
+  '@microsoft/fast-element@3.0.1': {}
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
@@ -9557,7 +9579,7 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@pnpm/tabtab@0.5.4(supports-color@10.2.2)':
+  '@pnpm/tabtab@0.5.4':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       enquirer: 2.4.1
@@ -9833,7 +9855,7 @@ snapshots:
 
   '@size-limit/esbuild@12.0.0(size-limit@12.0.0(jiti@2.6.1))':
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.7
       nanoid: 5.1.6
       size-limit: 12.0.0(jiti@2.6.1)
 
@@ -9854,29 +9876,29 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@9.1.20(@types/react@19.2.17)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))':
+  '@storybook/addon-docs@9.1.20(@types/react@19.2.17)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))
+      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))
       '@storybook/icons': 1.6.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))
+      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
       ts-dedent: 2.3.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/builder-vite@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))':
+  '@storybook/builder-vite@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))':
     dependencies:
-      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
+      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
       ts-dedent: 2.3.0
       vite: 7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)
 
-  '@storybook/csf-plugin@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))':
+  '@storybook/csf-plugin@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))':
     dependencies:
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
@@ -9886,26 +9908,26 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@storybook/react-dom-shim@9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))':
+  '@storybook/react-dom-shim@9.1.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))':
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
 
-  '@storybook/web-components-vite@9.1.20(lit@3.3.3)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))':
+  '@storybook/web-components-vite@9.1.20(lit@3.3.3)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))':
     dependencies:
-      '@storybook/builder-vite': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
-      '@storybook/web-components': 9.1.20(lit@3.3.3)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
+      '@storybook/builder-vite': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
+      '@storybook/web-components': 9.1.20(lit@3.3.3)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - lit
       - vite
 
-  '@storybook/web-components@9.1.20(lit@3.3.3)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))':
+  '@storybook/web-components@9.1.20(lit@3.3.3)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)))':
     dependencies:
       '@storybook/global': 5.0.0
       lit: 3.3.3
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
       tiny-invariant: 1.3.3
       ts-dedent: 2.3.0
 
@@ -10560,16 +10582,16 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.42.0(astro@6.3.1(@netlify/blobs@10.5.0(supports-color@10.2.2))(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))(jiti@2.6.1)(rollup@4.60.3)(supports-color@10.2.2)(terser@5.39.0)(yaml@2.9.0)):
+  astro-expressive-code@0.42.0(astro@6.3.1(@netlify/blobs@10.5.0)(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0)(jiti@2.6.1)(rollup@4.60.3)(terser@5.39.0)(yaml@2.9.0)):
     dependencies:
-      astro: 6.3.1(@netlify/blobs@10.5.0(supports-color@10.2.2))(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))(jiti@2.6.1)(rollup@4.60.3)(supports-color@10.2.2)(terser@5.39.0)(yaml@2.9.0)
+      astro: 6.3.1(@netlify/blobs@10.5.0)(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0)(jiti@2.6.1)(rollup@4.60.3)(terser@5.39.0)(yaml@2.9.0)
       rehype-expressive-code: 0.42.0
 
-  astro@6.3.1(@netlify/blobs@10.5.0(supports-color@10.2.2))(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))(jiti@2.6.1)(rollup@4.60.3)(supports-color@10.2.2)(terser@5.39.0)(yaml@2.9.0):
+  astro@6.3.1(@netlify/blobs@10.5.0)(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0)(jiti@2.6.1)(rollup@4.60.3)(terser@5.39.0)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.9.0
-      '@astrojs/markdown-remark': 7.1.1(supports-color@10.2.2)
+      '@astrojs/markdown-remark': 7.1.1
       '@astrojs/telemetry': 3.3.2
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.3.0
@@ -10615,7 +10637,7 @@ snapshots:
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
-      unstorage: 1.17.5(@netlify/blobs@10.5.0(supports-color@10.2.2))(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))
+      unstorage: 1.17.5(@netlify/blobs@10.5.0)(db0@0.3.1)(ioredis@5.6.0)
       vfile: 6.0.3
       vite: 7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)
       vitefu: 1.1.3(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0))
@@ -10740,11 +10762,11 @@ snapshots:
 
   bluebird@3.5.1: {}
 
-  body-parser@1.20.4(supports-color@10.2.2):
+  body-parser@1.20.4:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9(supports-color@10.2.2)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.1
@@ -11124,11 +11146,11 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  compression@1.8.1(supports-color@10.2.2):
+  compression@1.8.1:
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 2.6.9(supports-color@10.2.2)
+      debug: 2.6.9
       negotiator: 0.6.4
       on-headers: 1.1.0
       safe-buffer: 5.2.1
@@ -11275,11 +11297,9 @@ snapshots:
 
   debounce@1.2.1: {}
 
-  debug@2.6.9(supports-color@10.2.2):
+  debug@2.6.9:
     dependencies:
       ms: 2.0.0
-    optionalDependencies:
-      supports-color: 10.2.2
 
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
@@ -11356,10 +11376,10 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  detect-port@1.2.3(supports-color@10.2.2):
+  detect-port@1.2.3:
     dependencies:
       address: 1.2.2
-      debug: 2.6.9(supports-color@10.2.2)
+      debug: 2.6.9
     transitivePeerDependencies:
       - supports-color
 
@@ -11550,7 +11570,7 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
-  esbuild-register@3.6.0(esbuild@0.25.12)(supports-color@10.2.2):
+  esbuild-register@3.6.0(esbuild@0.25.12):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       esbuild: 0.25.12
@@ -11664,7 +11684,7 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-plugin-jsdoc@62.4.1(eslint@9.39.2(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2):
+  eslint-plugin-jsdoc@62.4.1(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@es-joy/jsdoccomment': 0.83.0
       '@es-joy/resolve.exports': 1.2.0
@@ -11672,7 +11692,7 @@ snapshots:
       comment-parser: 1.4.5
       debug: 4.4.3(supports-color@10.2.2)
       escape-string-regexp: 4.0.0
-      eslint: 9.39.2(jiti@2.6.1)(supports-color@10.2.2)
+      eslint: 9.39.2(jiti@2.6.1)
       espree: 11.1.0
       esquery: 1.7.0
       html-entities: 2.6.0
@@ -11695,14 +11715,14 @@ snapshots:
 
   eslint-visitor-keys@5.0.0: {}
 
-  eslint@9.39.2(jiti@2.6.1)(supports-color@10.2.2):
+  eslint@9.39.2(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.1(supports-color@10.2.2)
+      '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.3(supports-color@10.2.2)
+      '@eslint/eslintrc': 3.3.3
       '@eslint/js': 9.39.2
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
@@ -11859,21 +11879,21 @@ snapshots:
     dependencies:
       on-headers: 1.1.0
 
-  express@4.22.1(supports-color@10.2.2):
+  express@4.22.1:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.4(supports-color@10.2.2)
+      body-parser: 1.20.4
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.0.7
-      debug: 2.6.9(supports-color@10.2.2)
+      debug: 2.6.9
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.2(supports-color@10.2.2)
+      finalhandler: 1.3.2
       fresh: 0.5.2
       http-errors: 2.0.1
       merge-descriptors: 1.0.3
@@ -11885,8 +11905,8 @@ snapshots:
       qs: 6.14.1
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.2(supports-color@10.2.2)
-      serve-static: 1.16.3(supports-color@10.2.2)
+      send: 0.19.2
+      serve-static: 1.16.3
       setprototypeof: 1.2.0
       statuses: 2.0.2
       type-is: 1.6.18
@@ -11915,7 +11935,7 @@ snapshots:
 
   extend@3.0.2: {}
 
-  extract-zip@2.0.1(supports-color@10.2.2):
+  extract-zip@2.0.1:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       get-stream: 5.2.0
@@ -12063,9 +12083,9 @@ snapshots:
 
   filter-obj@6.1.0: {}
 
-  finalhandler@1.3.2(supports-color@10.2.2):
+  finalhandler@1.3.2:
     dependencies:
-      debug: 2.6.9(supports-color@10.2.2)
+      debug: 2.6.9
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -12113,7 +12133,7 @@ snapshots:
     dependencies:
       from2: 2.3.0
 
-  follow-redirects@1.15.11(debug@4.4.3(supports-color@10.2.2)):
+  follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3(supports-color@10.2.2)
 
@@ -12215,7 +12235,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  get-uri@6.0.5(supports-color@10.2.2):
+  get-uri@6.0.5:
     dependencies:
       basic-ftp: 5.1.0
       data-uri-to-buffer: 6.0.2
@@ -12477,7 +12497,7 @@ snapshots:
       unist-util-visit: 5.1.0
       zwitch: 2.0.4
 
-  hast-util-to-estree@3.1.3(supports-color@10.2.2):
+  hast-util-to-estree@3.1.3:
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -12487,9 +12507,9 @@ snapshots:
       estree-util-attach-comments: 3.0.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -12512,7 +12532,7 @@ snapshots:
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
-  hast-util-to-jsx-runtime@2.3.6(supports-color@10.2.2):
+  hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.4
@@ -12521,9 +12541,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -12629,27 +12649,27 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2(supports-color@10.2.2):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.9(debug@4.4.3(supports-color@10.2.2)):
+  http-proxy-middleware@2.0.9(debug@4.4.3):
     dependencies:
       '@types/http-proxy': 1.17.17
-      http-proxy: 1.18.1(debug@4.4.3(supports-color@10.2.2))
+      http-proxy: 1.18.1(debug@4.4.3)
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
     transitivePeerDependencies:
       - debug
 
-  http-proxy@1.18.1(debug@4.4.3(supports-color@10.2.2)):
+  http-proxy@1.18.1(debug@4.4.3):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.3(supports-color@10.2.2))
+      follow-redirects: 1.15.11(debug@4.4.3)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -12777,7 +12797,7 @@ snapshots:
     dependencies:
       kind-of: 6.0.3
 
-  ioredis@5.6.0(supports-color@10.2.2):
+  ioredis@5.6.0:
     dependencies:
       '@ioredis/commands': 1.7.0
       cluster-key-slot: 1.1.2
@@ -12798,7 +12818,7 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  ipx@3.1.1(@netlify/blobs@10.1.0)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2)):
+  ipx@3.1.1(@netlify/blobs@10.1.0)(db0@0.3.1)(ioredis@5.6.0):
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
       citty: 0.1.6
@@ -12814,7 +12834,7 @@ snapshots:
       sharp: 0.34.5
       svgo: 4.0.0
       ufo: 1.6.3
-      unstorage: 1.17.4(@netlify/blobs@10.1.0)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))
+      unstorage: 1.17.4(@netlify/blobs@10.1.0)(db0@0.3.1)(ioredis@5.6.0)
       xss: 1.0.15
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -13315,13 +13335,13 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-visit: 5.1.0
 
-  mdast-util-directive@3.1.0(supports-color@10.2.2):
+  mdast-util-directive@3.1.0:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -13336,14 +13356,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3(supports-color@10.2.2):
+  mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2(supports-color@10.2.2)
+      micromark: 4.0.2
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -13361,67 +13381,67 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0(supports-color@10.2.2):
+  mdast-util-gfm-footnote@2.1.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0(supports-color@10.2.2):
+  mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0(supports-color@10.2.2):
+  mdast-util-gfm-table@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0(supports-color@10.2.2):
+  mdast-util-gfm-task-list-item@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0(supports-color@10.2.2):
+  mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0(supports-color@10.2.2)
-      mdast-util-gfm-strikethrough: 2.0.0(supports-color@10.2.2)
-      mdast-util-gfm-table: 2.0.0(supports-color@10.2.2)
-      mdast-util-gfm-task-list-item: 2.0.0(supports-color@10.2.2)
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1(supports-color@10.2.2):
+  mdast-util-mdx-expression@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0(supports-color@10.2.2):
+  mdast-util-mdx-jsx@3.2.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
@@ -13429,7 +13449,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -13438,23 +13458,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx@3.0.0(supports-color@10.2.2):
+  mdast-util-mdx@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
-      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1(supports-color@10.2.2):
+  mdast-util-mdxjs-esm@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -13514,9 +13534,9 @@ snapshots:
 
   methods@1.1.2: {}
 
-  micro-compress@1.0.0(supports-color@10.2.2):
+  micro-compress@1.0.0:
     dependencies:
-      compression: 1.8.1(supports-color@10.2.2)
+      compression: 1.8.1
     transitivePeerDependencies:
       - supports-color
 
@@ -13785,7 +13805,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2(supports-color@10.2.2):
+  micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@10.2.2)
@@ -13927,7 +13947,7 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
-  netlify-cli@23.13.5(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))(picomatch@4.0.4)(rollup@4.60.3)(supports-color@10.2.2):
+  netlify-cli@23.13.5(@types/node@25.0.10)(db0@0.3.1)(ioredis@5.6.0)(picomatch@4.0.4)(rollup@4.60.3):
     dependencies:
       '@fastify/static': 7.0.4
       '@netlify/ai': 0.3.4(@netlify/api@14.0.12)
@@ -13946,7 +13966,7 @@ snapshots:
       '@netlify/zip-it-and-ship-it': 14.2.0(rollup@4.60.3)(supports-color@10.2.2)
       '@octokit/rest': 22.0.0
       '@opentelemetry/api': 1.8.0
-      '@pnpm/tabtab': 0.5.4(supports-color@10.2.2)
+      '@pnpm/tabtab': 0.5.4
       ansi-escapes: 7.1.1
       ansi-to-html: 0.7.2
       ascii-table: 0.0.9
@@ -13969,9 +13989,9 @@ snapshots:
       envinfo: 7.15.0
       etag: 1.8.1
       execa: 5.1.1
-      express: 4.22.1(supports-color@10.2.2)
+      express: 4.22.1
       express-logging: 1.1.1
-      extract-zip: 2.0.1(supports-color@10.2.2)
+      extract-zip: 2.0.1
       fastest-levenshtein: 1.0.16
       fastify: 4.29.1
       find-up: 7.0.0
@@ -13981,12 +14001,12 @@ snapshots:
       gh-release-fetch: 4.0.3
       git-repo-info: 2.1.1
       gitconfiglocal: 2.1.0
-      http-proxy: 1.18.1(debug@4.4.3(supports-color@10.2.2))
-      http-proxy-middleware: 2.0.9(debug@4.4.3(supports-color@10.2.2))
+      http-proxy: 1.18.1(debug@4.4.3)
+      http-proxy-middleware: 2.0.9(debug@4.4.3)
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       inquirer: 8.2.7(@types/node@25.0.10)
       inquirer-autocomplete-prompt: 1.4.0(inquirer@8.2.7(@types/node@25.0.10))
-      ipx: 3.1.1(@netlify/blobs@10.1.0)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2))
+      ipx: 3.1.1(@netlify/blobs@10.1.0)(db0@0.3.1)(ioredis@5.6.0)
       is-docker: 3.0.0
       is-stream: 4.0.1
       is-wsl: 3.1.0
@@ -14349,16 +14369,16 @@ snapshots:
     dependencies:
       p-timeout: 6.1.4
 
-  pac-proxy-agent@7.2.0(supports-color@10.2.2):
+  pac-proxy-agent@7.2.0:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)
-      get-uri: 6.0.5(supports-color@10.2.2)
-      http-proxy-agent: 7.0.2(supports-color@10.2.2)
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.5(supports-color@10.2.2)
+      socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14653,16 +14673,16 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-agent@6.5.0(supports-color@10.2.2):
+  proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)
-      http-proxy-agent: 7.0.2(supports-color@10.2.2)
+      http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0(supports-color@10.2.2)
+      pac-proxy-agent: 7.2.0
       proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.5(supports-color@10.2.2)
+      socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14904,11 +14924,11 @@ snapshots:
       hast-util-raw: 9.1.0
       vfile: 6.0.3
 
-  rehype-recma@1.0.0(supports-color@10.2.2):
+  rehype-recma@1.0.0:
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.4
-      hast-util-to-estree: 3.1.3(supports-color@10.2.2)
+      hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14925,7 +14945,7 @@ snapshots:
       rehype-stringify: 10.0.1
       unified: 11.0.5
 
-  release-it@19.2.4(@types/node@25.0.10)(magicast@0.5.2)(supports-color@10.2.2):
+  release-it@19.2.4(@types/node@25.0.10)(magicast@0.5.2):
     dependencies:
       '@nodeutils/defaults-deep': 1.1.0
       '@octokit/rest': 22.0.1
@@ -14943,7 +14963,7 @@ snapshots:
       open: 10.2.0
       ora: 9.0.0
       os-name: 6.1.0
-      proxy-agent: 6.5.0(supports-color@10.2.2)
+      proxy-agent: 6.5.0
       semver: 7.7.3
       tinyglobby: 0.2.15
       undici: 6.23.0
@@ -14955,37 +14975,37 @@ snapshots:
       - magicast
       - supports-color
 
-  remark-directive@4.0.0(supports-color@10.2.2):
+  remark-directive@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-directive: 3.1.0(supports-color@10.2.2)
+      mdast-util-directive: 3.1.0
       micromark-extension-directive: 4.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-gfm@4.0.1(supports-color@10.2.2):
+  remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0(supports-color@10.2.2)
+      mdast-util-gfm: 3.1.0
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-parse: 11.0.0
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-mdx@3.1.1(supports-color@10.2.2):
+  remark-mdx@3.1.1:
     dependencies:
-      mdast-util-mdx: 3.0.0(supports-color@10.2.2)
+      mdast-util-mdx: 3.0.0
       micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0(supports-color@10.2.2):
+  remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -15233,9 +15253,9 @@ snapshots:
 
   semver@7.7.4: {}
 
-  send@0.16.2(supports-color@10.2.2):
+  send@0.16.2:
     dependencies:
-      debug: 2.6.9(supports-color@10.2.2)
+      debug: 2.6.9
       depd: 1.1.2
       destroy: 1.0.4
       encodeurl: 1.0.2
@@ -15251,9 +15271,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@0.19.2(supports-color@10.2.2):
+  send@0.19.2:
     dependencies:
-      debug: 2.6.9(supports-color@10.2.2)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 2.0.0
@@ -15269,16 +15289,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.16.3(supports-color@10.2.2):
+  serve-static@1.16.3:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.2(supports-color@10.2.2)
+      send: 0.19.2
     transitivePeerDependencies:
       - supports-color
 
-  serve@6.5.8(supports-color@10.2.2):
+  serve@6.5.8:
     dependencies:
       args: 4.0.0
       basic-auth: 2.0.0
@@ -15287,20 +15307,20 @@ snapshots:
       chalk: 2.4.1
       clipboardy: 1.2.3
       dargs: 5.1.0
-      detect-port: 1.2.3(supports-color@10.2.2)
+      detect-port: 1.2.3
       filesize: 3.6.1
       fs-extra: 6.0.1
       handlebars: 4.0.11
       ip: 1.1.5
       micro: 9.3.1
-      micro-compress: 1.0.0(supports-color@10.2.2)
+      micro-compress: 1.0.0
       mime-types: 2.1.18
       node-version: 1.1.3
       openssl-self-signed-certificate: 1.1.6
       opn: 5.3.0
       path-is-inside: 1.0.2
       path-type: 3.0.0
-      send: 0.16.2(supports-color@10.2.2)
+      send: 0.16.2
       update-check: 1.5.1
     transitivePeerDependencies:
       - supports-color
@@ -15416,9 +15436,9 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-git@3.36.0(supports-color@10.2.2):
+  simple-git@3.36.0:
     dependencies:
-      '@kwsites/file-exists': 1.1.1(supports-color@10.2.2)
+      '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
       '@simple-git/args-pathspec': 1.0.3
       '@simple-git/argv-parser': 1.1.1
@@ -15426,9 +15446,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  simple-server@1.1.1(supports-color@10.2.2):
+  simple-server@1.1.1:
     dependencies:
-      serve: 6.5.8(supports-color@10.2.2)
+      serve: 6.5.8
     transitivePeerDependencies:
       - supports-color
 
@@ -15477,7 +15497,7 @@ snapshots:
 
   smol-toml@1.6.1: {}
 
-  socks-proxy-agent@8.0.5(supports-color@10.2.2):
+  socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)
@@ -15572,7 +15592,7 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(supports-color@10.2.2)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)):
+  storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@7.3.3(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.9.1
@@ -15582,7 +15602,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.25.12
-      esbuild-register: 3.6.0(esbuild@0.25.12)(supports-color@10.2.2)
+      esbuild-register: 3.6.0(esbuild@0.25.12)
       recast: 0.23.12
       semver: 7.7.4
       ws: 8.19.0
@@ -16047,7 +16067,7 @@ snapshots:
       acorn: 8.16.0
       webpack-virtual-modules: 0.6.2
 
-  unstorage@1.17.4(@netlify/blobs@10.1.0)(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2)):
+  unstorage@1.17.4(@netlify/blobs@10.1.0)(db0@0.3.1)(ioredis@5.6.0):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -16060,9 +16080,9 @@ snapshots:
     optionalDependencies:
       '@netlify/blobs': 10.1.0
       db0: 0.3.1
-      ioredis: 5.6.0(supports-color@10.2.2)
+      ioredis: 5.6.0
 
-  unstorage@1.17.5(@netlify/blobs@10.5.0(supports-color@10.2.2))(db0@0.3.1)(ioredis@5.6.0(supports-color@10.2.2)):
+  unstorage@1.17.5(@netlify/blobs@10.5.0)(db0@0.3.1)(ioredis@5.6.0):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -16075,7 +16095,7 @@ snapshots:
     optionalDependencies:
       '@netlify/blobs': 10.5.0(supports-color@10.2.2)
       db0: 0.3.1
-      ioredis: 5.6.0(supports-color@10.2.2)
+      ioredis: 5.6.0
 
   untildify@4.0.0: {}
 
@@ -16151,7 +16171,7 @@ snapshots:
 
   vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)(terser@5.39.0)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.6


### PR DESCRIPTION
The comparison guide cites a counter measured in each library but the
implementations lived nowhere in the repo. Add them, plus the benchmark
that produces the guide's numbers, as a runnable demo example, and link
the guide to it.

- demo/examples/library-comparison/counters/*.mjs — the same minimal
  counter (one reactive `count` prop, click handler, re-render) in
  web-component-base, Elena, Lit, FAST, and vanilla HTMLElement.
- index.html — all five running live side by side, with the methodology
  and the measured output table.
- measure.mjs — bundles each counter with its library runtime (esbuild
  --bundle --minify --format=esm) and compresses with gzip (-9) / brotli
  (q11) via Node zlib; reproduces the guide's numbers deterministically.
- Pin the three external libraries as demo devDependencies so the live
  demo and the benchmark resolve the same sources.
- Link the demo from the comparison guide and add a landing-page card.
